### PR TITLE
fix: wait shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,12 +49,15 @@ func main() {
 		Handler: newHandler(),
 	}
 
+	finish := make(chan struct{})
 	go func() {
 		<-ctx.Done()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		server.Shutdown(ctx)
+		close(finish)
 	}()
 	fmt.Fprintf(os.Stderr, "start receiving at :%d\n", env.Port)
 	fmt.Fprintln(os.Stderr, server.ListenAndServe())
+	<-finish
 }


### PR DESCRIPTION
ブログを拝見しました。良い記事をありがとうございます。
https://future-architect.github.io/articles/20210408/

Shutdownの完了を待たずにプロセスを終了しているようだったので、修正PRを送ります。

以下検証コード
```go
package main

import (
	"context"
	"log"
	"net/http"
	"os"
	"os/signal"
	"time"
)

func main() {
	mux := http.NewServeMux()
	mux.HandleFunc("/hello", func(rw http.ResponseWriter, r *http.Request) {
		log.Println("hello")
		time.Sleep(10 * time.Second)
		rw.Write([]byte("hello\n"))
	})
	srv := &http.Server{
		Addr:    ":8080",
		Handler: mux,
	}

	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
	defer cancel()

	finish := make(chan struct{})
	go func() {
		<-ctx.Done()
		log.Println("start shutdown")
		if err := srv.Shutdown(context.Background()); err != nil {
			log.Println(err)
		}
		log.Println("finish shutdown")
		close(finish)
	}()

	log.Println(srv.ListenAndServe())
	<-finish
	log.Println("see you")
}
```

このコードからfinishを消した状態でサーバーを立ち上げ、別端末などからcurlなどでリクエストを投げてレスポンスを待っている10秒の間にサーバーのプロセスをCtrl-Cで終了すると、シャットダウンを待たずにサーバーが終了して以下のようにクライアント側はエラーになります。

```
$ curl localhost:8080/hello -v
*   Trying ::1:8080...
* Connected to localhost (::1) port 8080 (#0)
> GET /hello HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.71.1
> Accept: */*
>
* Empty reply from server
* Connection #0 to host localhost left intact
curl: (52) Empty reply from server
```